### PR TITLE
fix: make urls argument required and clean up clap configuration

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -2,9 +2,8 @@ use clap::{ArgAction, Parser};
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "cloneit",
-    author = "Alok P",
-    version = "2.0.0",
+    author,
+    version,
     about = "Download GitHub directories/files",
     help_template = "\
 {before-help}{name} {version}
@@ -14,17 +13,18 @@ use clap::{ArgAction, Parser};
 {all-args}{after-help}
 ")]
 pub struct CommandArgs {
+    ///  URLs for GitHub directories or files. You can pass a single URL or multiple comma-delimited URLs
     #[arg(
         value_delimiter = ',',
         action = ArgAction::Set, 
         num_args = 1, 
-        help = "URL to the GitHub directory or file. You can pass a single URL or multiple comma-delimited URLs"
     )]
     pub urls: Vec<String>,
 
     #[arg()]
     pub path: Option<String>,
 
-    #[arg(short = 'z', long = "zip", help = "download and zip directory")]
+    /// Download and zip directories
+    #[arg(short = 'z', long = "zip")]
     pub zipped: bool,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -17,12 +17,12 @@ pub struct CommandArgs {
     #[arg(
         value_delimiter = ',',
         action = ArgAction::Set, 
-        num_args = 1, 
+        num_args(1..), 
         required = true,
     )]
     pub urls: Vec<String>,
 
-    #[arg()]
+    #[arg(short, long)]
     pub path: Option<String>,
 
     /// Download and zip directories

--- a/src/args.rs
+++ b/src/args.rs
@@ -13,7 +13,7 @@ use clap::{ArgAction, Parser};
 {all-args}{after-help}
 ")]
 pub struct CommandArgs {
-    ///  URLs for GitHub directories or files. You can pass a single URL or multiple comma-delimited URLs
+    /// URLs for GitHub directories or files to download. You can pass a single URL or multiple comma-delimited URLs
     #[arg(
         value_delimiter = ',',
         action = ArgAction::Set, 
@@ -26,6 +26,6 @@ pub struct CommandArgs {
     pub path: Option<String>,
 
     /// Download and zip directories
-    #[arg(short = 'z', long = "zip")]
+    #[arg(short, long = "zip")]
     pub zipped: bool,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,6 +18,7 @@ pub struct CommandArgs {
         value_delimiter = ',',
         action = ArgAction::Set, 
         num_args = 1, 
+        required = true,
     )]
     pub urls: Vec<String>,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -17,12 +17,12 @@ pub struct CommandArgs {
     #[arg(
         value_delimiter = ',',
         action = ArgAction::Set, 
-        num_args(1..), 
+        num_args = 1, 
         required = true,
     )]
     pub urls: Vec<String>,
 
-    #[arg(short, long)]
+    #[arg()]
     pub path: Option<String>,
 
     /// Download and zip directories


### PR DESCRIPTION
Switches to using doc comments for the help strings of flags, makes the URLs argument required, and removes extra configuration for clap that is the default.