### PR TITLE
feat: support `NO_COLOR` and `FORCE_COLOR`, remove progress bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,6 @@ version = "1.0.0"
 dependencies = [
  "async-recursion",
  "clap",
- "kdam",
  "proc-macro2",
  "reqwest",
  "serde",
@@ -189,6 +188,7 @@ dependencies = [
  "tokio",
  "url",
  "walkdir",
+ "yansi",
  "zip",
 ]
 
@@ -273,27 +273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,12 +314,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "formatx"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94c620058a2b0d38357c78968094788d66016c4cc24bb0efd2e246d9781391c"
 
 [[package]]
 name = "futures-channel"
@@ -554,12 +527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
-
-[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,17 +563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kdam"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef83391207724c1cd65d73afc5837d256f9e7a78d28c859c81eb6e62bac2dcc1"
-dependencies = [
- "formatx",
- "terminal_size",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,12 +573,6 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.0.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -1003,20 +953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.35.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,16 +1149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
-dependencies = [
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "time"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,12 +1297,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-xid"
@@ -1545,49 +1465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
 name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1472,12 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ async-recursion = "1.0.0"
 zip = "0.6" # for file-zipping related things
 walkdir = "2"
 proc-macro2 = "1.0.46"
-kdam = "0.2.3"
+yansi = "1.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::all)]
-use kdam::term::Colorizer;
 use std::io::Error;
 use std::process;
+use yansi::{Condition, Paint};
 use zip::result::ZipError;
 
 pub mod args;
@@ -18,18 +18,30 @@ use clap::Parser;
 async fn main() -> Result<(), Error> {
     let args = CommandArgs::parse();
 
+    const USE_COLOR: Condition = Condition(|| {
+        if std::env::var_os("FORCE_COLOR").is_some() {
+            true
+        } else if std::env::var_os("NO_COLOR").is_some() {
+            false
+        } else {
+            true
+        }
+    });
+
+    yansi::whenever(Condition::cached((USE_COLOR)()));
+
     for url in &args.urls {
         println!("Getting: {:?}", url);
         println!(
             "{} {}Validating url...",
-            "[1/3]".colorize("bold yellow"),
+            "[1/3]".bold().yellow(),
             output::LOOKING_GLASS
         );
 
         let path = match parser::parse_url(url) {
             Ok(path) => path,
             Err(err) => {
-                eprintln!("{}", err.to_string().colorize("red"));
+                eprintln!("{}", err.to_string().red());
                 process::exit(0);
             }
         };
@@ -37,25 +49,25 @@ async fn main() -> Result<(), Error> {
         let data = match parser::parse_path(&path, args.path.clone()) {
             Ok(data) => data,
             Err(err) => {
-                eprintln!("{}", err.to_string().colorize("red"));
+                eprintln!("{}", err.to_string().red());
                 process::exit(0);
             }
         };
 
         println!(
             "{} {}Downloading...",
-            "[2/3]".colorize("bold yellow"),
+            "[2/3]".bold().yellow(),
             output::TRUCK
         );
 
         match requests::fetch_data(&data).await {
             Err(err) => {
-                eprintln!("{}", err.to_string().colorize("red"));
+                eprintln!("{}", err.to_string().red());
                 process::exit(0);
             }
             Ok(_) => println!(
                 "{} {}Downloaded Successfully.",
-                "[3/3]".colorize("bold yellow"),
+                "[3/3]".bold().yellow(),
                 output::SPARKLES
             ),
         };
@@ -66,12 +78,9 @@ async fn main() -> Result<(), Error> {
             match zipper.run() {
                 Ok(_) => (),
                 Err(ZipError::FileNotFound) => {
-                    eprintln!(
-                        "{}",
-                        "\ncould not zip the downloaded file".colorize("bold red")
-                    )
+                    eprintln!("{}", "\ncould not zip the downloaded file".bold().red())
                 }
-                Err(e) => eprintln!("{}", e.to_string().colorize("bold red")),
+                Err(e) => eprintln!("{}", e.to_string().bold().red()),
             }
         }
     }

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -1,10 +1,10 @@
 use crate::parser::Directory;
 use async_recursion::async_recursion;
-use kdam::{term::Colorizer, tqdm, BarExt, Column, RichProgress};
-use reqwest::{header, Client};
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::{error::Error, path::Path};
 use tokio::io::AsyncWriteExt;
+use yansi::Paint;
 
 pub type ApiData = Vec<ApiObject>;
 
@@ -177,52 +177,12 @@ async fn write_file(
             let new_path = root_path.join(&obj.name);
 
             let mut res = client.get(download_url).send().await?;
-            let download_size = {
-                if res.status().is_success() {
-                    res.headers()
-                        .get(header::CONTENT_LENGTH)
-                        .and_then(|ct_len| ct_len.to_str().ok())
-                        .and_then(|ct_len| ct_len.parse().ok())
-                        .unwrap_or(0)
-                } else {
-                    return Err(format!(
-                        "Couldn't download file from URL\nError: {}",
-                        res.status()
-                    )
-                    .into());
-                }
-            };
-
-            let mut pb = RichProgress::new(
-                tqdm!(
-                    total = download_size,
-                    unit_scale = true,
-                    unit_divisor = 1024,
-                    unit = "B"
-                ),
-                vec![
-                    Column::text("[bold blue]?"),
-                    Column::Bar,
-                    Column::Percentage(1),
-                    Column::text("•"),
-                    Column::CountTotal,
-                    Column::text("•"),
-                    Column::Rate,
-                ],
-            );
-
-            pb.replace(0, Column::text(&format!("[bold blue]{}", &obj.name)));
 
             let mut outfile = tokio::fs::File::create(&new_path).await?;
-            let mut downloaded = 0;
             while let Some(chunk) = res.chunk().await? {
-                downloaded += chunk.len();
-                pb.update_to(downloaded);
                 outfile.write(&chunk).await?;
             }
 
-            pb.write(format!("downloaded {}", &obj.name).colorize("green"));
-            // pb.clear();
             Ok(())
         }
         None => return Err(format!("Could not get the download link!").into()),

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -183,6 +183,8 @@ async fn write_file(
                 outfile.write(&chunk).await?;
             }
 
+            println!("{}", format!("downloaded {}", obj.name).green());
+
             Ok(())
         }
         None => return Err(format!("Could not get the download link!").into()),


### PR DESCRIPTION
Currently a draft as I have yet to reimplement the progress bar (personally I don't think the bar is necessary, but I'll try to add it - possibly using https://docs.rs/indicatif/0.17.8/indicatif/ this time). Switches to using https://docs.rs/yansi/latest/yansi/index.html for terminal coloring, which is configured to disable color with https://no-color.org/ or enable it with https://force-color.org/.

Related to a comment in #8.