### PR TITLE
feat: overhaul logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +239,8 @@ version = "1.0.0"
 dependencies = [
  "async-recursion",
  "clap",
+ "env_logger",
+ "log",
  "proc-macro2",
  "reqwest",
  "serde",
@@ -191,6 +251,12 @@ dependencies = [
  "yansi",
  "zip",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "constant_time_eq"
@@ -270,6 +336,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -460,6 +549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +628,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,12 +687,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matches"
@@ -601,9 +699,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -907,6 +1005,35 @@ checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "remove_dir_all"
@@ -1317,6 +1444,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1596,79 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ zip = "0.6" # for file-zipping related things
 walkdir = "2"
 proc-macro2 = "1.0.46"
 yansi = "1.0.1"
+env_logger = "0.11.5"
+log = "0.4.22"

--- a/src/args.rs
+++ b/src/args.rs
@@ -28,4 +28,8 @@ pub struct CommandArgs {
     /// Download and zip directories
     #[arg(short, long = "zip")]
     pub zipped: bool,
+
+    /// Disable verbose logging
+    #[arg(short, long)]
+    pub quiet: bool,
 }

--- a/src/file_archiver.rs
+++ b/src/file_archiver.rs
@@ -59,7 +59,7 @@ impl ZipArchiver {
             // Write file or directory explicitly
             // Some unzip tools unzip files with directory paths correctly, some do not!
             if entry_path.is_file() {
-                println!("[+] Adding file {:?} as {:?} ...", entry_path, entry_name);
+                log::info!("[+] Adding file {:?} as {:?}...", entry_path, entry_name);
                 zip.start_file(entry_name, options)?;
                 let mut fh = File::open(entry_path)?;
 
@@ -69,7 +69,7 @@ impl ZipArchiver {
             } else if !entry_name.is_empty() {
                 // Only if not root! Avoids path spec / warning
                 // and mapname conversion failed error on unzip
-                println!("[+] Adding dir {:?} as {:?} ...", entry_path, entry_name);
+                log::info!("[+] Adding dir {:?} as {:?}...", entry_path, entry_name);
                 zip.add_directory(entry_name, options)?;
             }
         }
@@ -103,7 +103,7 @@ impl ZipArchiver {
             file,
         )?;
 
-        println!("[+] Zip archived: {:?}", &self.m_dest_zip_fname);
+        log::info!("[+] Zip archived as {:?}.", &self.m_dest_zip_fname);
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,14 @@ async fn main() -> Result<(), Error> {
 
     yansi::whenever(Condition::cached((USE_COLOR)()));
 
-    for url in &args.urls {
-        println!("Getting: {:?}", url);
+    let url_count = args.urls.len();
+    for (i, url) in args.urls.iter().enumerate() {
         println!(
-            "{} {}Validating url...",
+            "{} Cloning {url:?}...",
+            format!("[{}/{}]", i + 1, url_count + 1).bold().blue()
+        );
+        println!(
+            "{} {} Validating url...",
             "[1/3]".bold().yellow(),
             output::LOOKING_GLASS
         );
@@ -55,7 +59,7 @@ async fn main() -> Result<(), Error> {
         };
 
         println!(
-            "{} {}Downloading...",
+            "{} {} Downloading...",
             "[2/3]".bold().yellow(),
             output::TRUCK
         );
@@ -66,7 +70,7 @@ async fn main() -> Result<(), Error> {
                 process::exit(0);
             }
             Ok(_) => println!(
-                "{} {}Downloaded Successfully.",
+                "{} {} Downloaded successfully.",
                 "[3/3]".bold().yellow(),
                 output::SPARKLES
             ),
@@ -86,9 +90,12 @@ async fn main() -> Result<(), Error> {
     }
 
     println!(
-        "
-        [+] Downloaded {:?} dir(s).",
-        &args.urls.len()
+        "{} Downloaded {:?} director{}.",
+        format!("[{}/{}]", url_count + 1, url_count + 1)
+            .bold()
+            .blue(),
+        &url_count,
+        if url_count == 1 { "y" } else { "ies" },
     );
 
     Ok(())

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,3 +1,4 @@
 pub const LOOKING_GLASS: char = '\u{1F50D}';
 pub const TRUCK: char = '\u{1F69A}';
 pub const SPARKLES: char = '\u{2728}';
+pub const PACKAGE: char = '\u{1F4E6}';

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -190,7 +190,7 @@ async fn write_file(
                 outfile.write(&chunk).await?;
             }
 
-            println!("{}", format!("+ {}", obj.name).green());
+            log::info!("{}", format!("+ {}", obj.name).green());
 
             Ok(())
         }

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -190,7 +190,7 @@ async fn write_file(
                 outfile.write(&chunk).await?;
             }
 
-            println!("{}", format!("downloaded {}", obj.name).green());
+            println!("{}", format!("+ {}", obj.name).green());
 
             Ok(())
         }


### PR DESCRIPTION
Improves log messages, uses the `log` crate's macros instead of `println` and `eprintln`, uses `env_logger` for the RUST_LOG environment variable and `--quiet` flag.